### PR TITLE
add github workflow for releasing package to PyPI

### DIFF
--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -1,0 +1,65 @@
+name: Publish GenPackageDoc to PyPI
+
+on:
+  push:
+    tags:
+      - "rel/*.*.*"
+      - "rel/*.*.*.*"
+
+jobs:
+  build-n-publish:
+      name: Build and publish to PyPI
+      runs-on: ubuntu-latest
+
+      steps:
+        - name: Checkout source
+          uses: actions/checkout@v2
+
+        - name: Set up Python
+          uses: actions/setup-python@v4.3.0
+          with:
+            python-version: "3.9"
+
+        - name: Install dependencies
+          run: |
+            sudo apt-get install -y pandoc
+            sudo apt-get install -y texlive-latex-*
+            python -m pip install --upgrade build twine colorama pypandoc wheel dotdict
+
+        - name: Build source and wheel distributions
+          run: |
+            python setup.py sdist bdist_wheel
+            twine check --strict dist/*
+
+        - name: Publish distribution to PyPI
+          uses: pypa/gh-action-pypi-publish@release/v1
+          with:
+            password: ${{ secrets.PYPI_API_TOKEN }} # This token should be created in Settings > Secrets > Actions
+            # repository_url: https://test.pypi.org/legacy/ # Use this for testing to upload the distribution to test.pypi
+
+        - name: Create GitHub Release
+          id: create_release
+          uses: actions/create-release@v1.1.4
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+          with:
+            tag_name: ${{ github.ref }}
+            release_name: ${{ github.ref }}
+            draft: false
+            prerelease: false
+
+        - name: Get Asset name
+          run: |
+            export PKG=$(ls dist/ | grep tar)
+            set -- $PKG
+            echo "name=$1" >> $GITHUB_ENV
+        - name: Upload Release Asset (sdist) to GitHub
+          id: upload-release-asset
+          uses: actions/upload-release-asset@v1.0.2
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            upload_url: ${{ steps.create_release.outputs.upload_url }}
+            asset_path: dist/${{ env.name }}
+            asset_name: ${{ env.name }}
+            asset_content_type: application/zip


### PR DESCRIPTION
Hi Thomas,

This PR will add the new workflow in Github Actions for building and distributing the released package to PyPI. (Issue #30) 

Besides, I also add the jobs in workflow to create Github release and upload the distribution to that release, too.
(In case you do not need Github release, I will add the new commit to remove the regarding jobs)

Please refer the results as following links:
- Github Action job: https://github.com/ngoan1608/python-genpackagedoc/actions/runs/3426344847/jobs/5708036694
- Released package on test.pypi : https://test.pypi.org/manage/project/GenPackageDoc/releases/
- Github releases: https://github.com/ngoan1608/python-genpackagedoc/releases

Required actions from you:
- Create the API token from your account on PyPI: `Account settings > API tokens > Add API token`
- Add above API key as `PYPI_API_TOKEN` in the GitHub Secrets: go to repository `Settings > Secrets > Actions > New repository secret`
- Push new released tag e.g `rel/0.0.0.1` or `rel/0.0.1` to trigger the Github Actions `Publish GenPackageDoc to PyPI`.

Thank you,
Ngoan