### PR TITLE
update github workflow to allow update existing Github Release

### DIFF
--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -37,29 +37,16 @@ jobs:
             password: ${{ secrets.PYPI_API_TOKEN }} # This token should be created in Settings > Secrets > Actions
             # repository_url: https://test.pypi.org/legacy/ # Use this for testing to upload the distribution to test.pypi
 
-        - name: Create GitHub Release
-          id: create_release
-          uses: actions/create-release@v1.1.4
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-          with:
-            tag_name: ${{ github.ref }}
-            release_name: ${{ github.ref }}
-            draft: false
-            prerelease: false
-
         - name: Get Asset name
           run: |
             export PKG=$(ls dist/ | grep tar)
             set -- $PKG
             echo "name=$1" >> $GITHUB_ENV
-        - name: Upload Release Asset (sdist) to GitHub
-          id: upload-release-asset
-          uses: actions/upload-release-asset@v1.0.2
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        - name: Create/Update GitHub Release
+          id: create_update_release
+          uses: ncipollo/release-action@v1
           with:
-            upload_url: ${{ steps.create_release.outputs.upload_url }}
-            asset_path: dist/${{ env.name }}
-            asset_name: ${{ env.name }}
-            asset_content_type: application/zip
+            allowUpdates: true
+            omitNameDuringUpdate: true
+            artifacts: dist/${{ env.name }}


### PR DESCRIPTION
Hi Thomas,

I have updated the Github workflow according to your case.
Now it worked botch for cases:
1. Pushing new tag to repo
2. Manually create Github Release (and tag) with Github UI. 
   The same behavior with 1st case but updating (add built package to) existing Release Asset instead of creating new one.

I have very with personal repo. You can double check this change by increasing package version and new according tag.
In case, there is no issue, I will apply it for other repos.

Thank you,
Ngoan